### PR TITLE
Add v5 enhancement support files

### DIFF
--- a/Codigo/experiments/analysis/__init__.py
+++ b/Codigo/experiments/analysis/__init__.py
@@ -1,0 +1,1 @@
+"""Analysis helpers for SnapVM experiment outputs."""

--- a/Codigo/experiments/analysis/v5_plots.py
+++ b/Codigo/experiments/analysis/v5_plots.py
@@ -1,0 +1,253 @@
+"""V5 analysis and plotting pipeline."""
+
+import argparse
+import csv
+import statistics
+from collections import defaultdict
+from pathlib import Path
+from typing import Union
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+CSV_PATH = BASE_DIR / "results" / "v5_trials.csv"
+PLOT_DIR = BASE_DIR / "results" / "plots"
+
+PHASE_COLUMNS = [
+    "tokens_diagnosis",
+    "tokens_planning",
+    "tokens_manual_repair",
+    "tokens_snapshot_restore",
+    "tokens_checkpoint_save",
+    "tokens_checkpoint_restore",
+    "tokens_validation",
+    "tokens_final_response",
+    "tokens_other",
+]
+
+PHASE_LABELS = [column.replace("tokens_", "").replace("_", " ").title() for column in PHASE_COLUMNS]
+
+
+def load_csv(path: Union[str, Path]) -> list[dict]:
+    with open(path, newline="", encoding="utf-8") as handle:
+        return list(csv.DictReader(handle))
+
+
+def group_by_approach(rows: list[dict]) -> dict[str, list[dict]]:
+    groups = defaultdict(list)
+    for row in rows:
+        groups[row["approach"]].append(row)
+    return dict(groups)
+
+
+def _stats(values: list[float]) -> dict:
+    if not values:
+        return {"mean": 0, "median": 0, "stdev": 0, "n": 0}
+    return {
+        "mean": statistics.mean(values),
+        "median": statistics.median(values),
+        "stdev": statistics.stdev(values) if len(values) > 1 else 0,
+        "n": len(values),
+    }
+
+
+def compute_summary(groups: dict[str, list[dict]]) -> dict:
+    summary = {}
+    for approach, rows in groups.items():
+        n = len(rows)
+        successes = sum(1 for row in rows if row["success"] == "True")
+        phase_totals = {column: sum(int(row[column]) for row in rows) for column in PHASE_COLUMNS}
+        total_phase_tokens = sum(phase_totals.values())
+        summary[approach] = {
+            "n": n,
+            "success_count": successes,
+            "success_pct": (successes / n * 100) if n else 0,
+            "tokens_total": _stats([float(row["tokens_total"]) for row in rows]),
+            "latency_total": _stats([float(row["latency_total"]) for row in rows]),
+            "context_pollution": _stats([float(row["context_pollution"]) for row in rows]),
+            "tool_calls": _stats([float(row["tool_calls"]) for row in rows]),
+            "checkpoints_created": _stats([float(row["checkpoints_created"]) for row in rows]),
+            "checkpoints_restored": _stats([float(row["checkpoints_restored"]) for row in rows]),
+            "phase_totals": phase_totals,
+            "phase_share": {
+                column: (phase_totals[column] / total_phase_tokens * 100) if total_phase_tokens else 0
+                for column in PHASE_COLUMNS
+            },
+        }
+    return summary
+
+
+def print_summary(summary: dict):
+    print("\n" + "=" * 70)
+    print("V5 ENHANCED EXPERIMENT — SUMMARY")
+    print("=" * 70)
+    for approach, stats in summary.items():
+        print(f"\n── {approach} (n={stats['n']}) ──")
+        print(f"  Success: {stats['success_count']}/{stats['n']} ({stats['success_pct']:.1f}%)")
+        for metric in [
+            "tokens_total",
+            "latency_total",
+            "context_pollution",
+            "tool_calls",
+            "checkpoints_created",
+            "checkpoints_restored",
+        ]:
+            values = stats[metric]
+            print(
+                f"  {metric}: mean={values['mean']:.1f} "
+                f"median={values['median']:.1f} stdev={values['stdev']:.1f}"
+            )
+        print("  Phase token share:")
+        for column in PHASE_COLUMNS:
+            pct = stats["phase_share"][column]
+            if pct > 0.1:
+                print(f"    {column}: {pct:.1f}%")
+
+
+def _ensure_plot_dir(plot_dir: Union[str, Path]):
+    Path(plot_dir).mkdir(parents=True, exist_ok=True)
+
+
+def plot_success_rate(groups: dict, summary: dict, plot_dir: Union[str, Path]):
+    approaches = list(groups.keys())
+    rates = [summary[approach]["success_pct"] for approach in approaches]
+    counts = [f"{summary[approach]['success_count']}/{summary[approach]['n']}" for approach in approaches]
+
+    fig, ax = plt.subplots(figsize=(6, 4))
+    bars = ax.bar(approaches, rates, color=["#4C72B0", "#55A868"], width=0.5)
+    for bar, count, rate in zip(bars, counts, rates):
+        ax.text(
+            bar.get_x() + bar.get_width() / 2,
+            bar.get_height() + 1,
+            f"{rate:.1f}%\n({count})",
+            ha="center",
+            va="bottom",
+            fontsize=10,
+        )
+    ax.set_ylabel("Success Rate (%)")
+    ax.set_title("V5: Success Rate by Approach")
+    ax.set_ylim(0, 110)
+    plt.tight_layout()
+    plt.savefig(Path(plot_dir) / "v5_success_rate.png", dpi=150)
+    plt.close()
+
+
+def plot_success_strip(groups: dict, plot_dir: Union[str, Path]):
+    fig, ax = plt.subplots(figsize=(8, 3))
+    for index, (approach, rows) in enumerate(groups.items()):
+        outcomes = [1 if row["success"] == "True" else 0 for row in rows]
+        jitter = np.random.default_rng(42).uniform(-0.1, 0.1, len(outcomes))
+        colors = ["#55A868" if outcome else "#C44E52" for outcome in outcomes]
+        ax.scatter([index + delta for delta in jitter], outcomes, c=colors, alpha=0.7, s=30)
+        ax.text(index, -0.15, approach, ha="center", fontsize=9)
+    ax.set_yticks([0, 1])
+    ax.set_yticklabels(["Fail", "Pass"])
+    ax.set_xlim(-0.5, len(groups) - 0.5)
+    ax.set_title("V5: Per-Trial Outcomes")
+    ax.set_xticks([])
+    plt.tight_layout()
+    plt.savefig(Path(plot_dir) / "v5_success_strip.png", dpi=150)
+    plt.close()
+
+
+def plot_context_pollution(groups: dict, plot_dir: Union[str, Path]):
+    fig, ax = plt.subplots(figsize=(6, 4))
+    data = [[float(row["context_pollution"]) for row in rows] for rows in groups.values()]
+    ax.violinplot(data, positions=range(len(groups)), showmeans=True, showmedians=True)
+    ax.set_xticks(range(len(groups)))
+    ax.set_xticklabels(list(groups.keys()))
+    ax.set_ylabel("Context Pollution (tokens)")
+    ax.set_title("V5: Context Pollution")
+    plt.tight_layout()
+    plt.savefig(Path(plot_dir) / "v5_context_pollution.png", dpi=150)
+    plt.close()
+
+
+def plot_tokens_violin(groups: dict, plot_dir: Union[str, Path]):
+    fig, ax = plt.subplots(figsize=(6, 4))
+    data = [[float(row["tokens_total"]) for row in rows] for rows in groups.values()]
+    ax.violinplot(data, positions=range(len(groups)), showmeans=True, showmedians=True)
+    for index, values in enumerate(data):
+        jitter = np.random.default_rng(42).uniform(-0.05, 0.05, len(values))
+        ax.scatter([index + delta for delta in jitter], values, alpha=0.4, s=15, color="black")
+    ax.set_xticks(range(len(groups)))
+    ax.set_xticklabels(list(groups.keys()))
+    ax.set_ylabel("Total Tokens")
+    ax.set_title("V5: Total Token Usage")
+    plt.tight_layout()
+    plt.savefig(Path(plot_dir) / "v5_tokens_violin.png", dpi=150)
+    plt.close()
+
+
+def plot_phase_tokens_stacked(groups: dict, summary: dict, plot_dir: Union[str, Path]):
+    approaches = list(groups.keys())
+    fig, ax = plt.subplots(figsize=(8, 5))
+    bottoms = np.zeros(len(approaches))
+    colors = plt.cm.Set3(np.linspace(0, 1, len(PHASE_COLUMNS)))
+
+    for index, column in enumerate(PHASE_COLUMNS):
+        values = [summary[approach]["phase_totals"][column] for approach in approaches]
+        ax.bar(approaches, values, bottom=bottoms, color=colors[index], label=PHASE_LABELS[index])
+        bottoms += np.array(values, dtype=float)
+
+    ax.set_ylabel("Total Tokens (sum across trials)")
+    ax.set_title("V5: Phase Token Distribution (Stacked)")
+    ax.legend(bbox_to_anchor=(1.05, 1), loc="upper left", fontsize=8)
+    plt.tight_layout()
+    plt.savefig(Path(plot_dir) / "v5_phase_tokens_stacked.png", dpi=150, bbox_inches="tight")
+    plt.close()
+
+
+def plot_phase_tokens_share(groups: dict, summary: dict, plot_dir: Union[str, Path]):
+    approaches = list(groups.keys())
+    fig, axes = plt.subplots(1, len(approaches), figsize=(5 * len(approaches), 5))
+    if len(approaches) == 1:
+        axes = [axes]
+    colors = plt.cm.Set3(np.linspace(0, 1, len(PHASE_COLUMNS)))
+
+    for axis, approach in zip(axes, approaches):
+        shares = [summary[approach]["phase_share"][column] for column in PHASE_COLUMNS]
+        nonzero = [(share, label, color) for share, label, color in zip(shares, PHASE_LABELS, colors) if share > 0.5]
+        if nonzero:
+            values, labels, palette = zip(*nonzero)
+            axis.pie(values, labels=labels, colors=palette, autopct="%1.0f%%", textprops={"fontsize": 8})
+        axis.set_title(approach)
+
+    plt.suptitle("V5: Phase Token Share", fontsize=12)
+    plt.tight_layout()
+    plt.savefig(Path(plot_dir) / "v5_phase_tokens_share.png", dpi=150, bbox_inches="tight")
+    plt.close()
+
+
+def run_analysis(csv_path: Union[str, Path] = CSV_PATH, plot_dir: Union[str, Path] = PLOT_DIR):
+    rows = load_csv(csv_path)
+    groups = group_by_approach(rows)
+    summary = compute_summary(groups)
+
+    print_summary(summary)
+
+    _ensure_plot_dir(plot_dir)
+    plot_success_rate(groups, summary, plot_dir)
+    plot_success_strip(groups, plot_dir)
+    plot_context_pollution(groups, plot_dir)
+    plot_tokens_violin(groups, plot_dir)
+    plot_phase_tokens_stacked(groups, summary, plot_dir)
+    plot_phase_tokens_share(groups, summary, plot_dir)
+
+    print(f"\nPlots saved to {plot_dir}/")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="V5 analysis and plotting")
+    parser.add_argument("--csv", default=str(CSV_PATH), help="Input CSV path")
+    parser.add_argument("--plots", default=str(PLOT_DIR), help="Output plot directory")
+    args = parser.parse_args()
+    run_analysis(csv_path=args.csv, plot_dir=args.plots)
+
+
+if __name__ == "__main__":
+    main()

--- a/Codigo/experiments/src/orchestrator/dashboard.py
+++ b/Codigo/experiments/src/orchestrator/dashboard.py
@@ -1,0 +1,69 @@
+"""V5 dashboard — simple terminal progress output."""
+
+import time
+
+from .metrics import TrialRow
+
+
+class Dashboard:
+    """Small print-based progress display for v5 trials."""
+
+    def __init__(self, run_id: str, total_trials: int, model: str = "gpt-4o-mini"):
+        self.run_id = run_id
+        self.total_trials = total_trials
+        self.model = model
+        self.completed = 0
+        self.successes = 0
+        self._start = time.time()
+        print(f"\n{'═' * 60}")
+        print(f"  V5 Experiment | run={run_id} | model={model} | trials={total_trials}")
+        print(f"{'═' * 60}")
+
+    def start(self):
+        pass
+
+    def stop(self):
+        pass
+
+    def log(self, msg: str, style: str = ""):
+        print(f"  {msg}")
+
+    def set_approach(self, approach: str):
+        print(f"\n── {approach} ──")
+
+    def on_trial_start(self, trial_num: int):
+        print(f"  [{trial_num}/{self.total_trials}] running...", end="", flush=True)
+
+    def on_model_call(self, phase: str, prompt_tok: int, comp_tok: int):
+        pass
+
+    def on_tool_call(self, name: str, duration_ms: float = 0):
+        pass
+
+    def on_checkpoint_save(self, label: str, latency: float):
+        pass
+
+    def on_checkpoint_restore(self, latency: float):
+        pass
+
+    def on_trial_end(self, row: TrialRow):
+        self.completed += 1
+        if row.success:
+            self.successes += 1
+        rate = self.successes / self.completed * 100
+        elapsed = time.time() - self._start
+        eta = (elapsed / self.completed) * (self.total_trials - self.completed)
+        status = "✓" if row.success else "✗"
+        print(
+            f" {status} tok={row.tokens_total} lat={row.latency_total:.1f}s | "
+            f"rate={self.successes}/{self.completed} ({rate:.0f}%) | ETA {eta:.0f}s"
+        )
+
+    def on_infra_error(self, error: str):
+        print(f"  ⚠ INFRA: {error[:80]}")
+
+    def on_experiment_done(self):
+        elapsed = time.time() - self._start
+        print(f"\n{'═' * 60}")
+        print(f"  DONE | {self.completed} trials | {self.successes} passed | {elapsed:.0f}s")
+        print(f"{'═' * 60}")

--- a/Codigo/experiments/src/orchestrator/metrics.py
+++ b/Codigo/experiments/src/orchestrator/metrics.py
@@ -1,0 +1,176 @@
+"""V5 token ledger — phase-level metric accounting and CSV serialization."""
+
+import csv
+import os
+import time
+from dataclasses import asdict, dataclass
+from enum import Enum
+
+
+class Phase(str, Enum):
+    DIAGNOSIS = "diagnosis"
+    PLANNING = "planning"
+    MANUAL_REPAIR = "manual_repair"
+    SNAPSHOT_RESTORE = "snapshot_restore"
+    CHECKPOINT_SAVE = "checkpoint_save"
+    CHECKPOINT_RESTORE = "checkpoint_restore"
+    VALIDATION = "validation"
+    FINAL_RESPONSE = "final_response"
+    OTHER = "other"
+
+
+CSV_COLUMNS = [
+    "run_id", "trial_id", "experiment", "approach", "strategy",
+    "success", "failure_reason",
+    "tokens_total", "tokens_diagnosis", "tokens_planning",
+    "tokens_manual_repair", "tokens_snapshot_restore",
+    "tokens_checkpoint_save", "tokens_checkpoint_restore",
+    "tokens_validation", "tokens_final_response", "tokens_other",
+    "latency_total", "tool_calls", "context_pollution",
+    "checkpoints_created", "checkpoints_restored",
+    "start_time", "end_time", "trial_status", "seed", "scenario_id", "notes",
+]
+
+
+@dataclass
+class TrialRow:
+    run_id: str = ""
+    trial_id: str = ""
+    experiment: str = "v5"
+    approach: str = ""
+    strategy: str = ""
+    success: bool = False
+    failure_reason: str = ""
+    tokens_total: int = 0
+    tokens_diagnosis: int = 0
+    tokens_planning: int = 0
+    tokens_manual_repair: int = 0
+    tokens_snapshot_restore: int = 0
+    tokens_checkpoint_save: int = 0
+    tokens_checkpoint_restore: int = 0
+    tokens_validation: int = 0
+    tokens_final_response: int = 0
+    tokens_other: int = 0
+    latency_total: float = 0.0
+    tool_calls: int = 0
+    context_pollution: int = 0
+    checkpoints_created: int = 0
+    checkpoints_restored: int = 0
+    start_time: str = ""
+    end_time: str = ""
+    trial_status: str = ""
+    seed: str = ""
+    scenario_id: str = "v5_long_task"
+    notes: str = ""
+
+    def phase_sum(self) -> int:
+        return (
+            self.tokens_diagnosis
+            + self.tokens_planning
+            + self.tokens_manual_repair
+            + self.tokens_snapshot_restore
+            + self.tokens_checkpoint_save
+            + self.tokens_checkpoint_restore
+            + self.tokens_validation
+            + self.tokens_final_response
+            + self.tokens_other
+        )
+
+    def validate(self) -> bool:
+        """Return True if the phase totals match the recorded total."""
+        return self.tokens_total == self.phase_sum()
+
+    def to_dict(self) -> dict:
+        data = asdict(self)
+        data["success"] = str(data["success"])
+        return data
+
+
+class TokenLedger:
+    """Accumulates token events by phase and serializes a trial row."""
+
+    def __init__(self, run_id: str, approach: str, trial_number: int, seed: str = ""):
+        self.run_id = run_id
+        self.trial_id = f"{run_id}_{trial_number:03d}"
+        self.approach = approach
+        self.seed = seed
+        self._phase_tokens = {phase: 0 for phase in Phase}
+        self._tool_calls = 0
+        self._context_pollution = 0
+        self._checkpoints_created = 0
+        self._checkpoints_restored = 0
+        self._excluded_time = 0.0
+        self._start = time.time()
+        self._start_iso = time.strftime("%Y-%m-%dT%H:%M:%S")
+
+    def record(self, phase: Phase, prompt_tokens: int, completion_tokens: int):
+        self._phase_tokens[phase] += prompt_tokens + completion_tokens
+
+    def record_tool_call(self):
+        self._tool_calls += 1
+
+    def record_checkpoint_save(self):
+        self._checkpoints_created += 1
+
+    def record_checkpoint_restore(self):
+        self._checkpoints_restored += 1
+
+    def set_context_pollution(self, tokens: int):
+        self._context_pollution = tokens
+
+    def exclude_time(self, seconds: float):
+        """Exclude rate-limit backoff wait from the final latency."""
+        self._excluded_time += seconds
+
+    def finalize(self, success: bool, failure_reason: str = "", notes: str = "") -> TrialRow:
+        end_iso = time.strftime("%Y-%m-%dT%H:%M:%S")
+        latency = time.time() - self._start - self._excluded_time
+        total = sum(self._phase_tokens.values())
+
+        row = TrialRow(
+            run_id=self.run_id,
+            trial_id=self.trial_id,
+            approach=self.approach,
+            strategy=self.approach,
+            success=success,
+            failure_reason=failure_reason,
+            tokens_total=total,
+            tokens_diagnosis=self._phase_tokens[Phase.DIAGNOSIS],
+            tokens_planning=self._phase_tokens[Phase.PLANNING],
+            tokens_manual_repair=self._phase_tokens[Phase.MANUAL_REPAIR],
+            tokens_snapshot_restore=self._phase_tokens[Phase.SNAPSHOT_RESTORE],
+            tokens_checkpoint_save=self._phase_tokens[Phase.CHECKPOINT_SAVE],
+            tokens_checkpoint_restore=self._phase_tokens[Phase.CHECKPOINT_RESTORE],
+            tokens_validation=self._phase_tokens[Phase.VALIDATION],
+            tokens_final_response=self._phase_tokens[Phase.FINAL_RESPONSE],
+            tokens_other=self._phase_tokens[Phase.OTHER],
+            latency_total=latency,
+            tool_calls=self._tool_calls,
+            context_pollution=self._context_pollution,
+            checkpoints_created=self._checkpoints_created,
+            checkpoints_restored=self._checkpoints_restored,
+            start_time=self._start_iso,
+            end_time=end_iso,
+            trial_status="valid",
+            seed=self.seed,
+            notes=notes,
+        )
+
+        if not row.validate():
+            row.trial_status = "instrumentation-invalid"
+
+        return row
+
+
+def write_csv_row(path: str, row: TrialRow):
+    """Append a row to CSV, creating the file and header when needed."""
+    file_exists = os.path.isfile(path)
+    parent = os.path.dirname(path)
+    if parent:
+        os.makedirs(parent, exist_ok=True)
+
+    with open(path, "a", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=CSV_COLUMNS)
+        if not file_exists:
+            writer.writeheader()
+        writer.writerow(row.to_dict())

--- a/Codigo/experiments/tests/test_v5_metrics.py
+++ b/Codigo/experiments/tests/test_v5_metrics.py
@@ -1,0 +1,167 @@
+"""Tests for V5 metrics schema validation and token aggregation."""
+
+import csv
+import io
+import os
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+
+from analysis import v5_plots
+from src.orchestrator.dashboard import Dashboard
+from src.orchestrator.metrics import CSV_COLUMNS, Phase, TokenLedger, TrialRow, write_csv_row
+
+
+class TestTrialRow(unittest.TestCase):
+    def test_phase_sum_matches_total(self):
+        row = TrialRow(tokens_total=100, tokens_diagnosis=40, tokens_planning=30, tokens_validation=30)
+        self.assertTrue(row.validate())
+
+    def test_phase_sum_mismatch_fails_validation(self):
+        row = TrialRow(tokens_total=999, tokens_diagnosis=10)
+        self.assertFalse(row.validate())
+
+    def test_to_dict_has_all_csv_columns(self):
+        row = TrialRow()
+        data = row.to_dict()
+        for column in CSV_COLUMNS:
+            self.assertIn(column, data)
+
+    def test_success_serialized_as_string(self):
+        row = TrialRow(success=True)
+        self.assertEqual(row.to_dict()["success"], "True")
+
+
+class TestTokenLedger(unittest.TestCase):
+    def test_record_accumulates_by_phase(self):
+        ledger = TokenLedger(run_id="r1", approach="Checkpoint", trial_number=1)
+        ledger.record(Phase.DIAGNOSIS, prompt_tokens=50, completion_tokens=20)
+        ledger.record(Phase.DIAGNOSIS, prompt_tokens=10, completion_tokens=5)
+        ledger.record(Phase.VALIDATION, prompt_tokens=30, completion_tokens=10)
+        row = ledger.finalize(success=True)
+        self.assertEqual(row.tokens_diagnosis, 85)
+        self.assertEqual(row.tokens_validation, 40)
+        self.assertEqual(row.tokens_total, 125)
+        self.assertTrue(row.validate())
+
+    def test_finalize_sets_instrumentation_invalid_on_mismatch(self):
+        ledger = TokenLedger(run_id="r1", approach="Standard/Manual", trial_number=1)
+        ledger.record(Phase.DIAGNOSIS, 10, 10)
+        row = ledger.finalize(success=True)
+        row.tokens_total = 999
+        self.assertFalse(row.validate())
+
+    def test_checkpoint_counters(self):
+        ledger = TokenLedger(run_id="r1", approach="Checkpoint", trial_number=1)
+        ledger.record_checkpoint_save()
+        ledger.record_checkpoint_save()
+        ledger.record_checkpoint_restore()
+        ledger.record(Phase.CHECKPOINT_SAVE, 10, 5)
+        row = ledger.finalize(success=True)
+        self.assertEqual(row.checkpoints_created, 2)
+        self.assertEqual(row.checkpoints_restored, 1)
+
+    def test_standard_approach_zero_checkpoints(self):
+        ledger = TokenLedger(run_id="r1", approach="Standard/Manual", trial_number=1)
+        ledger.record(Phase.MANUAL_REPAIR, 50, 50)
+        row = ledger.finalize(success=False, failure_reason="table missing")
+        self.assertEqual(row.checkpoints_created, 0)
+        self.assertEqual(row.checkpoints_restored, 0)
+
+    def test_tool_call_counter(self):
+        ledger = TokenLedger(run_id="r1", approach="Standard/Manual", trial_number=1)
+        ledger.record_tool_call()
+        ledger.record_tool_call()
+        ledger.record_tool_call()
+        ledger.record(Phase.DIAGNOSIS, 10, 10)
+        row = ledger.finalize(success=True)
+        self.assertEqual(row.tool_calls, 3)
+
+
+class TestWriteCsv(unittest.TestCase):
+    def test_csv_has_correct_header_and_row(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "test.csv")
+            row = TrialRow(
+                run_id="abc",
+                trial_id="abc_001",
+                approach="Checkpoint",
+                success=True,
+                tokens_total=100,
+                tokens_diagnosis=100,
+            )
+            write_csv_row(path, row)
+            write_csv_row(path, row)
+
+            with open(path, newline="", encoding="utf-8") as handle:
+                reader = csv.DictReader(handle)
+                self.assertEqual(reader.fieldnames, CSV_COLUMNS)
+                rows = list(reader)
+                self.assertEqual(len(rows), 2)
+                self.assertEqual(rows[0]["run_id"], "abc")
+                self.assertEqual(rows[0]["success"], "True")
+
+
+class TestV5Analysis(unittest.TestCase):
+    def test_analysis_writes_expected_plots(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            csv_path = os.path.join(tmp, "v5_trials.csv")
+            plot_dir = os.path.join(tmp, "plots")
+
+            rows = [
+                TrialRow(
+                    run_id="run1",
+                    trial_id="run1_001",
+                    approach="Standard/Manual",
+                    strategy="Standard/Manual",
+                    success=True,
+                    tokens_total=120,
+                    tokens_diagnosis=40,
+                    tokens_planning=20,
+                    tokens_manual_repair=40,
+                    tokens_validation=20,
+                ),
+                TrialRow(
+                    run_id="run1",
+                    trial_id="run1_002",
+                    approach="Checkpoint",
+                    strategy="Checkpoint",
+                    success=True,
+                    tokens_total=140,
+                    tokens_diagnosis=30,
+                    tokens_planning=20,
+                    tokens_checkpoint_save=10,
+                    tokens_checkpoint_restore=10,
+                    tokens_validation=70,
+                ),
+            ]
+            for row in rows:
+                write_csv_row(csv_path, row)
+
+            with redirect_stdout(io.StringIO()):
+                v5_plots.run_analysis(csv_path=csv_path, plot_dir=plot_dir)
+
+            expected = {
+                "v5_success_rate.png",
+                "v5_success_strip.png",
+                "v5_context_pollution.png",
+                "v5_tokens_violin.png",
+                "v5_phase_tokens_stacked.png",
+                "v5_phase_tokens_share.png",
+            }
+            produced = set(os.listdir(plot_dir))
+            self.assertTrue(expected.issubset(produced))
+
+
+class TestDashboard(unittest.TestCase):
+    def test_on_trial_end_updates_counters(self):
+        with redirect_stdout(io.StringIO()):
+            dash = Dashboard(run_id="run1", total_trials=2)
+            dash.on_trial_end(TrialRow(success=True, tokens_total=10, latency_total=1.2))
+
+        self.assertEqual(dash.completed, 1)
+        self.assertEqual(dash.successes, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds the SnapVM v5 enhancement support modules and analysis pipeline without removing any existing code.

Included:
- phase-level token ledger and CSV serialization
- terminal dashboard helper
- CSV-driven v5 plotting pipeline
- schema/aggregation/plot tests